### PR TITLE
mysql-redshift ddlscan template: Remove UNSIGNED attribute from DECIMAL column type

### DIFF
--- a/replicator/support/ddlscan/includes/ddl-mysql-redshift-table.vm
+++ b/replicator/support/ddlscan/includes/ddl-mysql-redshift-table.vm
@@ -31,7 +31,7 @@ INT##
 #elseif ( $col.getTypeDescription().startsWith("BIGINT") )
 BIGINT##
 #elseif ( $col.getTypeDescription().startsWith("DECIMAL(") )
-$col.getTypeDescription()##
+$col.getTypeDescription().replaceFirst(" UNSIGNED","")##
 #elseif ( $col.getTypeDescription().startsWith("VARCHAR") )
 #set ( $varCharLen = $col.getLength() * 4 )
 #if ( $varCharLen <= 65000 )


### PR DESCRIPTION
Using ddlscan to generate create statements will generate invalid statements for Reshift, if a DECIMAL column with the UNSIGNED attribute in MySQL is present. UNSIGNED isn't supported by Redshift/PostgreSQL.

http://docs.aws.amazon.com/redshift/latest/dg/r_Numeric_types201.html
http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
