### PR TITLE
Handle JSON datatype as BLOB to avoid termination of the replication …

### DIFF
--- a/replicator/src/java/com/continuent/tungsten/replicator/extractor/mysql/MysqlBinlog.java
+++ b/replicator/src/java/com/continuent/tungsten/replicator/extractor/mysql/MysqlBinlog.java
@@ -321,6 +321,7 @@ public class MysqlBinlog
     public static final int                     MYSQL_TYPE_TIMESTAMP2               = 17;
     public static final int                     MYSQL_TYPE_DATETIME2                = 18;
     public static final int                     MYSQL_TYPE_TIME2                    = 19;
+    public static final int                     MYSQL_TYPE_JSON                     = 245;
     public static final int                     MYSQL_TYPE_NEWDECIMAL               = 246;
     public static final int                     MYSQL_TYPE_ENUM                     = 247;
     public static final int                     MYSQL_TYPE_SET                      = 248;

--- a/replicator/src/java/com/continuent/tungsten/replicator/extractor/mysql/RowsLogEvent.java
+++ b/replicator/src/java/com/continuent/tungsten/replicator/extractor/mysql/RowsLogEvent.java
@@ -991,7 +991,7 @@ public abstract class RowsLogEvent extends LogEvent
                     spec.setType(java.sql.Types.INTEGER);
                 return length;
 
-            case MysqlBinlog.MYSQL_TYPE_BLOB :
+            case MysqlBinlog.MYSQL_TYPE_BLOB : case MysqlBinlog.MYSQL_TYPE_JSON :
                 /*
                  * BLOB or TEXT datatype
                  */

--- a/replicator/src/java/com/continuent/tungsten/replicator/extractor/mysql/TableMapLogEvent.java
+++ b/replicator/src/java/com/continuent/tungsten/replicator/extractor/mysql/TableMapLogEvent.java
@@ -141,6 +141,7 @@ public class TableMapLogEvent extends LogEvent
             {
                 case MysqlBinlog.MYSQL_TYPE_TINY_BLOB :
                 case MysqlBinlog.MYSQL_TYPE_BLOB :
+                case MysqlBinlog.MYSQL_TYPE_JSON :
                 case MysqlBinlog.MYSQL_TYPE_MEDIUM_BLOB :
                 case MysqlBinlog.MYSQL_TYPE_LONG_BLOB :
                 case MysqlBinlog.MYSQL_TYPE_DOUBLE :


### PR DESCRIPTION
…process if Binlog contains JSON types (unsupported types can later be filtered by extractor filters).